### PR TITLE
Undo button

### DIFF
--- a/src/blocks/CalligraphyApp.tsx
+++ b/src/blocks/CalligraphyApp.tsx
@@ -236,7 +236,7 @@ interface CalligraphyPaletteProps {
 }
 const CalligraphyPalette = (props: CalligraphyPaletteProps) => {
   return (
-    <div className='flex flex-row flex-wrap gap-2 py-2 border-2 rounded-md bg-[#fbfbfb] justify-start'>
+    <div className='flex flex-row flex-wrap gap-2 py-2 border-2 rounded-md bg-[#fbfbfb] justify-start overflow-x-auto'>
       {props.colors.map (color =>
         <ColorSwatch key={color} color={color} onClick={() => props.onColorSelected(color)} activeColor={props.activeColor} />
       )}
@@ -255,7 +255,7 @@ const CalligraphyBackgroundSelectorTab = (props: CalligraphyBackgroundSelectorPr
     "dots":dots
   }
   return (
-    <div className='flex space-between'>
+    <div className='flex space-between overflow-x-auto'>
       {Object.entries(backgroundOptions).map(( [background,imgPath] )=>
         <img 
         className={`basis-1/3 border-[#d903ff] rounded-lg m-[10px] ${props.currentBackground === background ? "border-2" : "border-0"} `}

--- a/src/blocks/CalligraphyApp.tsx
+++ b/src/blocks/CalligraphyApp.tsx
@@ -280,21 +280,21 @@ const CalligraphyToolbar = (props: CalligraphyToolbarProps) => {
     <div className='flex justify-between'>
       <div className='flex gap-4 border-2 rounded-full p-4 bg-[#fbfbfb]'>
         <div
-          className='flex flex-0 w-10 h-10 rounded-full bg-[#ededed] place-items-center place-content-center border-fuchsia-500'
+          className='flex flex-0 w-10 h-10 rounded-full active:bg-slate-300 bg-[#ededed] place-items-center place-content-center border-fuchsia-500'
           onClick={() => props.setActivePaletteTab(PaletteTab.COLOR)}
           style={{ borderWidth: props.activePaletteTab === PaletteTab.COLOR ? '2px' : '0px' }}
         >
           <div className='w-8 h-8 rounded-full border border-white' style={{ backgroundColor: props.activeColor }} />
         </div>
         <div
-          className='flex flex-0 w-10 h-10 rounded-full bg-[#ededed] place-items-center place-content-center border-fuchsia-500'
+          className='flex flex-0 w-10 h-10 rounded-full active:bg-slate-300 bg-[#ededed] place-items-center place-content-center border-fuchsia-500'
           onClick={() => props.setActivePaletteTab(PaletteTab.BRUSH)}
           style={{ borderWidth: props.activePaletteTab === PaletteTab.BRUSH ? '2px' : '0px' }}
         >
           <EditIcon />
         </div>
         <div
-          className='flex flex-0 w-10 h-10 rounded-full bg-[#ededed] place-items-center place-content-center border-fuchsia-500'
+          className='flex flex-0 w-10 h-10 rounded-full active:bg-slate-300 bg-[#ededed] place-items-center place-content-center border-fuchsia-500'
           onClick={() => props.setActivePaletteTab(PaletteTab.BACKGROUND)}
           style={{ borderWidth: props.activePaletteTab === PaletteTab.BACKGROUND ? '2px' : '0px' }}
         >
@@ -302,8 +302,8 @@ const CalligraphyToolbar = (props: CalligraphyToolbarProps) => {
         </div>
       </div>
       <div className='flex gap-4 border-2 rounded-full p-4 bg-[#fbfbfb]'>
-        <div onClick={props.toggleCanvasUndoSwitch} className='flex flex-0 w-10 h-10 rounded-full bg-[#ededed] place-items-center place-content-center'><UndoIcon /></div>
-        <div onClick={props.toggleCanvasClearSwitch}className='flex flex-0 w-10 h-10 rounded-full bg-[#ededed] place-items-center place-content-center'><CloseIcon /></div>
+        <div onClick={props.toggleCanvasUndoSwitch} className='flex flex-0 active:bg-slate-300 w-10 h-10 rounded-full bg-[#ededed] place-items-center place-content-center'><UndoIcon /></div>
+        <div onClick={props.toggleCanvasClearSwitch}className='flex flex-0 active:bg-slate-300 w-10 h-10 rounded-full bg-[#ededed] place-items-center place-content-center'><CloseIcon /></div>
       </div>   </div>
   )
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 41fba97da06a39debcdb48694c1381ce6cb70f6a  | 
|--------|--------|

### Summary:
Added undo functionality to CalligraphyApp with an undo buffer to restore the previous canvas state.

**Key points**:
- Added undo functionality to `src/blocks/CalligraphyApp.tsx`.
- Introduced `undoBuffer` in `CalligraphyCanvas` to store the previous state of the canvas.
- Updated `sketch` function to handle undo operation by clearing the buffer and restoring the previous state from `undoBuffer`.
- Modified `mousePressed` function to save the current state to `undoBuffer` before starting a new stroke.
- Added `mouseOffCanvas` function to prevent drawing outside the canvas.
- Updated toolbar buttons to include active state styling.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->