### PR TITLE
adds brush1 and spray brush

### DIFF
--- a/src/blocks/CalligraphyApp.tsx
+++ b/src/blocks/CalligraphyApp.tsx
@@ -50,7 +50,7 @@ const CalligraphyCanvas = (props: CalligraphyCanvasProps) => {
     let localUndoSwitch = state.current.canvasUndoSwitch;
     /**namespaces for each brush option */
     const ink = {
-      BRUSH_SIZE : 25, //make configurable later?
+      BRUSH_SIZE : 15, //make configurable later?
       VEL_DEPENDENT_SHADE : false, //make the stroke lighter the faster the brush moves
       previousStrokeWidth : 0, //stroke width on prior frame
       FRICTION : 2, //divides velocity
@@ -62,7 +62,7 @@ const CalligraphyCanvas = (props: CalligraphyCanvasProps) => {
       currentStrokeTotalLength : 0
     }
     const brush1 = {
-      brushSize : 15,
+      brushSize : 20,
       f : true,
       spring : 0.4,
       friction : 0.45,
@@ -436,7 +436,9 @@ const CalligraphyBackgroundSelector = (props: CalligraphyBackgroundSelectorProps
 
 // Available options for the brush selector
 const brushOptions: Record<string, string> = {
-  'ink': brushInk
+  'ink': brushInk,
+  'brush1': brushInk,
+  'spray': brushInk
 }
 type CalligraphyBrush = keyof typeof brushOptions;
 // Component for selecting the brush


### PR DESCRIPTION
Adds our first third party brush and establishes a pattern for different draw() loops and namespaces for each brush
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d0827fae16de70e4e144188d5f9c9885793f26a9  | 
|--------|--------|

### Summary:
Added `brush1`, `spray`, and `streak` brushes, and refactored code to support multiple brushes with different draw loops in `src/blocks/CalligraphyApp.tsx`.

**Key points**:
- Added `brush1`, `spray`, and `streak` brushes in `src/blocks/CalligraphyApp.tsx`.
- Refactored `CalligraphyCanvas` component to support multiple brushes using namespaces (`ink`, `brush1`, `spray`, `streak`).
- Updated `sketch` function in `CalligraphyCanvas` to handle different brush behaviors.
- Set default brush to `spray` in `CalligraphyEdit` component.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->